### PR TITLE
Manufacturing research tweaks

### DIFF
--- a/1.6/Patches/MSS_Bootlegger_ManufacteringBenchs.xml
+++ b/1.6/Patches/MSS_Bootlegger_ManufacteringBenchs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationRemove">
+        <xpath>Defs/ResearchProjectDef[defName="VFE_Manufacturing"]/prerequisites</xpath>
+    </Operation>
+    <Operation Class="PatchOperationReplace">
+        <xpath>Defs/ResearchProjectDef[defName="VFE_Manufacturing"]/baseCost</xpath>
+        <value>
+          <baseCost>3000</baseCost>
+        </value>
+    </Operation>
+</Patch>


### PR DESCRIPTION
The VFE Manufacturing research is way to expensive and for some arbitrary reason it needs fabrication research in order to be researched. The research already prevents you from making the large machining bench without having machining unlocked so why require fabrication. 
This patch fixes this by yeeting that requirement. The cost of the research is reduced to unify it with many surrounding research tasks

Hope this helps
